### PR TITLE
MULE-13883: Soap Service loses metadata

### DIFF
--- a/src/main/kotlin/org/mule/wsdl/parser/WsdlSchemasCollector.kt
+++ b/src/main/kotlin/org/mule/wsdl/parser/WsdlSchemasCollector.kt
@@ -1,5 +1,6 @@
 package org.mule.wsdl.parser
 
+import net.sf.saxon.jaxp.IdentityTransformer
 import net.sf.saxon.jaxp.SaxonTransformerFactory
 import org.mule.metadata.xml.api.SchemaCollector
 import org.w3c.dom.Node
@@ -105,12 +106,14 @@ class WsdlSchemasCollector(private val definition: Definition) {
       val writer = StringWriter()
       val source = DOMSource(node)
       val result = StreamResult(writer)
-      val idTransformer = SaxonTransformerFactory.newInstance()
-      val transformer = idTransformer.newTransformer()
+      val factory = SaxonTransformerFactory()
+      val transformer = factory.newTransformer()
       transformer.transform(source, result)
       return writer.toString()
     } catch (e: Exception) {
       throw RuntimeException("Error transforming node to String", e)
     }
   }
+
+
 }

--- a/src/main/kotlin/org/mule/wsdl/parser/WsdlSchemasCollector.kt
+++ b/src/main/kotlin/org/mule/wsdl/parser/WsdlSchemasCollector.kt
@@ -114,6 +114,4 @@ class WsdlSchemasCollector(private val definition: Definition) {
       throw RuntimeException("Error transforming node to String", e)
     }
   }
-
-
 }


### PR DESCRIPTION
SaxonTransformerFactory does not override the `newInstance` method from the base JDK TransformerFactory which uses SPI to create instances, this way doing `SaxonTransformerFactory.newInstance` would never return a SaxonTransformerFactory instance  using mule.