### PR TITLE
EE-6629: Fix jenkins pipeline used to runtimeProjectsBuild which does…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ def UPSTREAM_PROJECTS_LIST = [ "Mule-runtime/metadata-model-api/master" ]
 
 Map pipelineParams = [ "upstreamProjects" : UPSTREAM_PROJECTS_LIST.join(',') ]
 
-runtimeExtensionsBuild(pipelineParams)
+runtimeProjectsBuild(pipelineParams)


### PR DESCRIPTION
…n't have the corrupted snapshot validation.