### PR TITLE
Mule-18024: Added a WsdlGettingException

### DIFF
--- a/src/main/kotlin/org/mule/wsdl/parser/exception/WsdlGettingException.kt
+++ b/src/main/kotlin/org/mule/wsdl/parser/exception/WsdlGettingException.kt
@@ -1,0 +1,5 @@
+package org.mule.wsdl.parser.exception
+
+class WsdlGettingException(message: String?, cause: Throwable?) : Exception(message, cause) {
+  constructor(message: String?) : this(message, null)
+}

--- a/src/main/kotlin/org/mule/wsdl/parser/locator/WsdlLocator.kt
+++ b/src/main/kotlin/org/mule/wsdl/parser/locator/WsdlLocator.kt
@@ -2,6 +2,7 @@ package org.mule.wsdl.parser.locator
 
 import org.apache.cxf.resource.URIResolver
 import org.apache.cxf.wsdl11.CatalogWSDLLocator
+import org.mule.wsdl.parser.exception.WsdlGettingException
 import org.mule.wsdl.parser.exception.WsdlParsingException
 import org.xml.sax.InputSource
 import java.io.IOException
@@ -91,6 +92,8 @@ internal class WsdlLocator(private val wsdlLocation: String, private val resourc
       val source = InputSource(resource)
       sources[url] = source
       return source
+    } catch (e: IOException) {
+      throw WsdlGettingException("Error Getting the resource [$url]: " + e.message, e)
     } catch (e: Exception) {
       throw WsdlParsingException("Error fetching the resource [$url]: " + e.message, e)
     }

--- a/src/test/kotlin/org/mule/connectivity/soap/WsdlParserTestCase.kt
+++ b/src/test/kotlin/org/mule/connectivity/soap/WsdlParserTestCase.kt
@@ -23,6 +23,7 @@ import org.mockserver.socket.PortFactory
 import org.mule.connectivity.soap.TestUtils.getResourcePath
 import org.mule.wsdl.parser.WsdlParser
 import org.mule.wsdl.parser.exception.OperationNotFoundException
+import org.mule.wsdl.parser.exception.WsdlGettingException
 import org.mule.wsdl.parser.exception.WsdlParsingException
 import org.mule.wsdl.parser.model.WsdlStyle
 import org.mule.wsdl.parser.model.version.SoapVersion
@@ -152,8 +153,8 @@ class WsdlParserTestCase {
       }
     }
     val resource = "http://localhost:$freePort/test?wsdl"
-    val msg = "Error fetching the resource [$resource]: Server returned HTTP response code: 401 for URL: $resource"
-    func shouldThrowTheException WsdlParsingException::class withMessage msg
+    val msg = "Error Getting the resource [$resource]: Server returned HTTP response code: 401 for URL: $resource"
+    func shouldThrowTheException WsdlGettingException::class withMessage msg
   }
 
   @Test


### PR DESCRIPTION
Added a WsdlGettingException in order to handle actual connection problems getting a wsdl, so those errors will not be treated as parsing errors.
Mule-18024