### PR TITLE
W-14073604: Update dokka-maven-plugin to 1.9.0 to work with Java 11+ …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,9 +374,19 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <configuration>
+                        <!-- Skipping javadoc plugin to avoid errors "No public or protected classes found to document"
+                        and because the dokka-maven-plugin is used to generate the docs -->
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.jetbrains.dokka</groupId>
                         <artifactId>dokka-maven-plugin</artifactId>
-                        <version>0.9.16</version>
+                        <version>1.9.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
…and skip maven-javadoc-plugin as it is not needed because it is used the dokka-maven-plugin for that

